### PR TITLE
Add "lein-git-inject/sha" with configurable :sha-length

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The four special strings supported - referred to as `substitution keys` - are:
 |   substitution key                    |    example replacement       |
 |---------------------------------------|------------------------------|
 | "lein-git-inject/version"             |  "12.4.1-2-453a730-SNAPSHOT" |
+| "lein-git-inject/sha"                 |  "d7b932f7"                  |
 | "lein-git-inject/build-iso-date-time" |  "2019-11-18T00:05:02.273361"|      
 | "lein-git-inject/build-iso-date-week" |  "2019-W47-2"                |
 | "lein-git-inject/user-name"           | "Isaac"                      |
@@ -143,6 +144,7 @@ A map of configuration options can, optionally, be added to `defproject` via the
 The two configuration options are:
   -  `:ignore-dirty?` 
   -  `:version-pattern` 
+  -  `:sha-length`
   
 #### :ignore-dirty?
 
@@ -188,7 +190,11 @@ The regex you supply has two jobs:
   :version-pattern  #"^version\/(.*)$" 
 }
 ```
-  
+
+#### :sha-length
+
+An integer which specifies the length of the output git SHA used when replacing `"lein-git-inject/sha".
+
 ## An Annotated Example
 
 Here's how to write your `project.clj` ... 


### PR DESCRIPTION
This is a lightweight PR to add `:sha-length` because I wanted to use this for my SHA-based automation, which doesn't use traditional versions via git tags.

I *do* like some of the benefits proposed by capturing the git context in the `lein-git-inject/version` -- and I initially set out to customize the `git-status-to-version` function. I noticed that this function wasn't configurable to skip the `git tag` checks & considered adding options like `:git-inject {:version-basis "tag || sha"}` which could skip tag checks when making the git-context strings... but I wasn't sure if these sort of assumptions were contrary to the vision for `lein-git-inject`.

I'm willing to do some refactor to this PR if you have a good idea on how to solve the problem I mentioned above. If this isn't part of `lein-git-inject`'s vision I'm also happy to move to a different lein plugin, but the "early in buildtime git injection" nature of this plugin made it seem an appropriate place for this.